### PR TITLE
Correct Load_plugin_textdomain()

### DIFF
--- a/preferred-languages.php
+++ b/preferred-languages.php
@@ -29,7 +29,7 @@
  */
 
 function preferred_languages_load_textdomain() {
-	load_plugin_textdomain( 'preferred-languages', false, basename( __FILE__ ) . '/languages' );
+	load_plugin_textdomain( 'preferred-languages', false, basename( dirname( __FILE__ ) ) . '/languages' );
 }
 
 add_action( 'init', 'preferred_languages_load_textdomain' );


### PR DESCRIPTION
The plugin is calling translation file from:
.../wp-content/plugins/preferred-languages **.php** /languages/preferred-languages-xx_XX.mo
Correct it to:
.../wp-content/plugins/preferred-languages/languages/preferred-languages-xx_XX.mo