### PR TITLE
Don't check for `install_languages` cap if language is already installed

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -233,16 +233,23 @@ function preferred_languages_update_option( $old_value, $value ) {
  * @return array|false The installed language packs or false on failure.
  */
 function preferred_languages_download_language_packs( $locales ) {
-	if ( ! current_user_can( 'install_languages' ) ) {
-		return false;
-	}
-
 	// Handle translation install.
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
-	$installed_languages = array();
+	$installed_languages            = array();
+	$available_languages            = get_available_languages();
+	$current_user_install_languages = current_user_can( 'install_languages' );
 
 	foreach ( $locales as $locale ) {
+		if ( in_array( $locale, $available_languages, true ) ) {
+			$installed_languages[] = $locale;
+			continue;
+		}
+
+		if ( ! $current_user_install_languages ) {
+			continue;
+		}
+
 		$language = wp_download_language_pack( $locale );
 		if ( $language ) {
 			$installed_languages[] = $language;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -230,15 +230,15 @@ function preferred_languages_update_option( $old_value, $value ) {
  * @since 1.0.0
  *
  * @param array $locales The language packs to install.
- * @return array|false The installed language packs or false on failure.
+ * @return array The installed and available languages.
  */
 function preferred_languages_download_language_packs( $locales ) {
 	// Handle translation install.
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
-	$installed_languages            = array();
-	$available_languages            = get_available_languages();
-	$current_user_install_languages = current_user_can( 'install_languages' );
+	$installed_languages        = array();
+	$available_languages        = get_available_languages();
+	$user_can_install_languages = current_user_can( 'install_languages' );
 
 	foreach ( $locales as $locale ) {
 		if ( in_array( $locale, $available_languages, true ) ) {
@@ -246,7 +246,7 @@ function preferred_languages_download_language_packs( $locales ) {
 			continue;
 		}
 
-		if ( ! $current_user_install_languages ) {
+		if ( ! $user_can_install_languages ) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #48.