### PR TITLE
Translation merging

### DIFF
--- a/inc/default-filters.php
+++ b/inc/default-filters.php
@@ -27,5 +27,5 @@ add_filter( 'update_user_metadata', 'preferred_languages_pre_update_user_meta', 
 add_filter( 'update_user_meta', 'preferred_languages_update_user_meta', 10, 4 );
 add_filter( 'get_user_metadata', 'preferred_languages_filter_user_locale', 10, 3 );
 add_filter( 'locale', 'preferred_languages_filter_locale', 5 ); // Before WP_Locale_Switcher.
-add_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile' );
+add_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile', 10, 2 );
 add_filter( 'load_script_translation_file', 'preferred_languages_load_script_translation_file' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -325,14 +325,11 @@ function preferred_languages_filter_user_locale( $value, $object_id, $meta_key )
  * @since 1.0.0
  *
  * @param string $mofile Path to the MO file.
+ * @param string $domain Text domain. Unique identifier for retrieving translated strings.
  *
  * @return string The modified MO file path.
  */
-function preferred_languages_load_textdomain_mofile( $mofile ) {
-	if ( is_readable( $mofile ) ) {
-		return $mofile;
-	}
-
+function preferred_languages_load_textdomain_mofile( $mofile, $domain ) {
 	$preferred_locales = preferred_languages_get_list();
 
 	if ( empty( $preferred_locales ) ) {
@@ -346,12 +343,26 @@ function preferred_languages_load_textdomain_mofile( $mofile ) {
 		return $mofile;
 	}
 
+	$first_mofile = null;
+
+	remove_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile' );
+
 	foreach ( $preferred_locales as $locale ) {
 		$preferred_mofile = str_replace( $current_locale, $locale, $mofile );
 
 		if ( is_readable( $preferred_mofile ) ) {
-			return $preferred_mofile;
+			load_textdomain( $domain, $preferred_mofile );
+
+			if ( null === $first_mofile ) {
+				$first_mofile = $preferred_mofile;
+			}
 		}
+	}
+
+	add_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile', 10, 2 );
+
+	if( null !== $first_mofile ) {
+		return $first_mofile;
 	}
 
 	return $mofile;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -347,12 +347,12 @@ function preferred_languages_load_textdomain_mofile( $mofile, $domain ) {
 
 	remove_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile' );
 
+	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
+
 	foreach ( $preferred_locales as $locale ) {
 		$preferred_mofile = str_replace( $current_locale, $locale, $mofile );
 
 		if ( is_readable( $preferred_mofile ) ) {
-			$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $locale, $current_locale );
-
 			if( !$merge_translations ) {
 				return $preferred_mofile;
 			}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -351,6 +351,12 @@ function preferred_languages_load_textdomain_mofile( $mofile, $domain ) {
 		$preferred_mofile = str_replace( $current_locale, $locale, $mofile );
 
 		if ( is_readable( $preferred_mofile ) ) {
+			$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $locale, $current_locale );
+
+			if( !$merge_translations ) {
+				return $preferred_mofile;
+			}
+
 			load_textdomain( $domain, $preferred_mofile );
 
 			if ( null === $first_mofile ) {


### PR DESCRIPTION
Rework of #249, adding the option to optionally merge multiple translations.

The option to merge a translation into an existing one can be enabled on a per domain and locale basis, using the `preferred_languages_merge_translations` filter.  eg;


```php
add_filter( 'preferred_languages_merge_translations', '__return_true' );

// Or
add_filter( 'preferred_languages_merge_translations', function ( $merge, $domain, $current_locale ) {
    if ( $current_locale === 'nl_BE' ) {
        return true;
    }

    return $merge;
}, 10, 3 );
```