### PR TITLE
Bail early in `preferred_languages_override_load_textdomain()`

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -493,7 +493,7 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 	if ( ! $merge_translations ) {
 		return $override;
 	}
-	
+
 	$preferred_locales = preferred_languages_get_list();
 
 	if ( empty( $preferred_locales ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -477,19 +477,6 @@ function preferred_languages_filter_user_locale( $value, $object_id, $meta_key )
  * @return bool Whether to override the .mo file loading.
  */
 function preferred_languages_override_load_textdomain( $override, $domain, $mofile ) {
-	$preferred_locales = preferred_languages_get_list();
-
-	if ( empty( $preferred_locales ) ) {
-		return $override;
-	}
-
-	$current_locale = determine_locale();
-
-	// Locale has been filtered by something else.
-	if ( ! in_array( $current_locale, $preferred_locales, true ) ) {
-		return $override;
-	}
-
 	/**
 	 * Filters whether translations should be merged with existing ones.
 	 *
@@ -502,6 +489,19 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
 
 	if ( ! $merge_translations ) {
+		return $override;
+	}
+	
+	$preferred_locales = preferred_languages_get_list();
+
+	if ( empty( $preferred_locales ) ) {
+		return $override;
+	}
+
+	$current_locale = determine_locale();
+
+	// Locale has been filtered by something else.
+	if ( ! in_array( $current_locale, $preferred_locales, true ) ) {
 		return $override;
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -477,6 +477,8 @@ function preferred_languages_filter_user_locale( $value, $object_id, $meta_key )
  * @return bool Whether to override the .mo file loading.
  */
 function preferred_languages_override_load_textdomain( $override, $domain, $mofile ) {
+	$current_locale = determine_locale();
+
 	/**
 	 * Filters whether translations should be merged with existing ones.
 	 *
@@ -497,8 +499,6 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 	if ( empty( $preferred_locales ) ) {
 		return $override;
 	}
-
-	$current_locale = determine_locale();
 
 	// Locale has been filtered by something else.
 	if ( ! in_array( $current_locale, $preferred_locales, true ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -590,23 +590,23 @@ function preferred_languages_load_textdomain_mofile( $mofile ) {
  * @return string|false|null JSON-encoded translation data.
  */
 function preferred_languages_pre_load_script_translations( $translations, $file, $handle, $domain ) {
+	$current_locale = determine_locale();
+
+	/** This filter is documented in inc/functions.php */
+	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
+
+	if ( ! $merge_translations ) {
+		return $translations;
+	}
+
 	$preferred_locales = preferred_languages_get_list();
 
 	if ( empty( $preferred_locales ) ) {
 		return $translations;
 	}
 
-	$current_locale = determine_locale();
-
 	// Locale has been filtered by something else.
 	if ( ! in_array( $current_locale, $preferred_locales, true ) ) {
-		return $translations;
-	}
-
-	/** This filter is documented in inc/functions.php */
-	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
-
-	if ( ! $merge_translations ) {
 		return $translations;
 	}
 


### PR DESCRIPTION
If the merge of translations isn't enabled we don't have to check the current and preferred locales. This will reduce the number of `apply_filters` calls ~down to just one~.