### PR TITLE
Fix implode error

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -996,7 +996,10 @@ function preferred_languages_filter_debug_information( $args ) {
 	}
 
 	if ( isset( $args['wp-core']['fields']['user_language']['value'] ) ) {
-		$args['wp-core']['fields']['user_language']['value'] = implode( ', ', preferred_languages_get_user_list() ?: array() );
+		$users = preferred_languages_get_user_list();
+		if ( is_array( $users ) ) {
+			$args['wp-core']['fields']['user_language']['value'] = implode( ', ', $users );
+		}
 	}
 
 	return $args;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -992,7 +992,7 @@ function preferred_languages_filter_gettext( $translation, $text, $domain ) {
  */
 function preferred_languages_filter_debug_information( $args ) {
 	if ( isset( $args['wp-core']['fields']['site_language']['value'] ) ) {
-		$args['wp-core']['fields']['site_language']['value'] = implode( ', ', preferred_languages_get_site_list() ?: array() );
+		$args['wp-core']['fields']['site_language']['value'] = implode( ', ', preferred_languages_get_site_list() );
 	}
 
 	if ( isset( $args['wp-core']['fields']['user_language']['value'] ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -992,11 +992,11 @@ function preferred_languages_filter_gettext( $translation, $text, $domain ) {
  */
 function preferred_languages_filter_debug_information( $args ) {
 	if ( isset( $args['wp-core']['fields']['site_language']['value'] ) ) {
-		$args['wp-core']['fields']['site_language']['value'] = implode( ', ', preferred_languages_get_site_list() );
+		$args['wp-core']['fields']['site_language']['value'] = implode( ', ', preferred_languages_get_site_list() ?: array() );
 	}
 
 	if ( isset( $args['wp-core']['fields']['user_language']['value'] ) ) {
-		$args['wp-core']['fields']['user_language']['value'] = implode( ', ', preferred_languages_get_user_list() );
+		$args['wp-core']['fields']['user_language']['value'] = implode( ', ', preferred_languages_get_user_list() ?: array() );
 	}
 
 	return $args;


### PR DESCRIPTION
Without this patch, on the Site Health page you get this error:
```
 Warning: implode(): Invalid arguments passed in wp-content/plugins/preferred-languages/inc/functions.php on line 999
```
because `preferred_languages_get_user_list()` can return an array or `false` and you cannot `implode( ',', false )`.

<img width="868" alt="Screenshot 2023-01-10 at 22 28 46" src="https://user-images.githubusercontent.com/203408/211666668-78f8df59-a3c9-4b53-826e-4664d5c95192.png">
