### PR TITLE
Bail early if there is no script translation file

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -640,6 +640,10 @@ function preferred_languages_pre_load_script_translations( $translations, $file,
  * @return string The modified JSON file path.
  */
 function preferred_languages_load_script_translation_file( $file ) {
+	if ( ! $file ) {
+		return $file;
+	}
+
 	$preferred_locales = preferred_languages_get_list();
 
 	if ( empty( $preferred_locales ) ) {

--- a/tests/phpunit/tests/plugin.php
+++ b/tests/phpunit/tests/plugin.php
@@ -1042,6 +1042,14 @@ class Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::preferred_languages_load_script_translation_file
 	 */
+	public function test_load_script_translation_file_no_file() {
+		$actual = preferred_languages_load_script_translation_file( false );
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * @covers ::preferred_languages_load_script_translation_file
+	 */
 	public function test_load_script_translation_file_no_preferred_locales() {
 		$actual = preferred_languages_load_script_translation_file( 'foo' );
 		$this->assertSame( 'foo', $actual );


### PR DESCRIPTION
Noticed while looking at #674.

`$file` can be `false`, so it would be silly to anything further like calling `str_replace` or `is_readable` on something that's `false`