### PR TITLE
CI: replace `mysqladmin` health check command

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -80,12 +80,13 @@ jobs:
             mysql:
                 image: mariadb:latest
                 env:
-                    MYSQL_ALLOW_EMPTY_PASSWORD: true
-                    MYSQL_ROOT_PASSWORD: ''
-                    MYSQL_DATABASE: wordpress_test
+                    MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+                    MARIADB_DATABASE: wordpress_test
+                    MARIADB_MYSQL_LOCALHOST_USER: 1
+                    MARIADB_MYSQL_LOCALHOST_GRANTS: USAGE
                 ports:
                     - 3306
-                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+                options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -150,7 +150,8 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mariadb-admin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA || \
+		mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
 install_wp


### PR DESCRIPTION
Recent container releases deprecated mysqladmin and use mariadb-admin. The server code will eventually follow suite.

In this change, we use the container healthcheck.sh script to use the mysql@localhost user and check to see if the connection is there on TCP (which it didn't before), and that the install-wp-tests.sh will use mariadb-admin and fall back to mysqladmin if needed.

The MYSQL_ROOT_PASSWORD = '' was implied by the ${MYSQL|MARIADB}_ALLOW_EMPTY{_ROOT}_PASSWORD.

Technically the improved healthcheck should make "Verify MariaDB connection" obsolete.