### PR TITLE
Add site list caching to improve performance

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -190,6 +190,7 @@ function preferred_languages_get_user_list( $user_id = 0 ) {
  * @return array Preferred languages.
  */
 function preferred_languages_get_site_list() {
+	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/** @var null|array $cache */
 	static $cache;
 	if ( is_array( $cache ) ) {
@@ -197,7 +198,7 @@ function preferred_languages_get_site_list() {
 	}
 
 	$preferred_languages = get_option( 'preferred_languages', '' );
-	$cache = array_filter( explode( ',', $preferred_languages ) );
+	$cache               = array_filter( explode( ',', $preferred_languages ) );
 	return $cache;
 }
 
@@ -209,13 +210,14 @@ function preferred_languages_get_site_list() {
  * @return array Preferred languages.
  */
 function preferred_languages_get_network_list() {
+	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/** @var null|array $cache */
 	static $cache;
 	if ( is_array( $cache ) ) {
 		return $cache;
 	}
 	$preferred_languages = get_site_option( 'preferred_languages', '' );
-	$cache = array_filter( explode( ',', $preferred_languages ) );
+	$cache               = array_filter( explode( ',', $preferred_languages ) );
 	return $cache;
 }
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -190,8 +190,15 @@ function preferred_languages_get_user_list( $user_id = 0 ) {
  * @return array Preferred languages.
  */
 function preferred_languages_get_site_list() {
+	/** @var null|array $cache */
+	static $cache;
+	if ( is_array( $cache ) ) {
+		return $cache;
+	}
+
 	$preferred_languages = get_option( 'preferred_languages', '' );
-	return array_filter( explode( ',', $preferred_languages ) );
+	$cache = array_filter( explode( ',', $preferred_languages ) );
+	return $cache;
 }
 
 /**
@@ -202,8 +209,14 @@ function preferred_languages_get_site_list() {
  * @return array Preferred languages.
  */
 function preferred_languages_get_network_list() {
+	/** @var null|array $cache */
+	static $cache;
+	if ( is_array( $cache ) ) {
+		return $cache;
+	}
 	$preferred_languages = get_site_option( 'preferred_languages', '' );
-	return array_filter( explode( ',', $preferred_languages ) );
+	$cache = array_filter( explode( ',', $preferred_languages ) );
+	return $cache;
 }
 
 /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The functions `preferred_languages_get_site_list()` and `preferred_languages_get_network_list()` (on multisites) are called for _every_ translation function call (`__()`, `_e()`, `esc_html__()`, `esc_html_e()`, etc.). This means that for bigger projects, they are called very often, sometimes several thousand times. Both functions call `get_option()`, causing a high number of requests to the database. When no permanent object cache is in place or is misconfigured, the performance is negatively affected.


**What is the new behavior (if this is a feature change)?**
A static variable is introduced, preventing the need to call `get_option` on subsequent calls to `preferred_languages_get_(site|network)_list()`.
This considerably improves performance by avoiding redundant database queries when the site list is requested multiple times while executing a script or request.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Please note that WordPress caches the `.mo` file path, but not in every case. We haven't checked this in detail, but it could be related to cases where we don't have matching translations.