### PR TITLE
Support WordPress 6.5

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,7 @@
 		"https://downloads.wordpress.org/plugin/performant-translations.zip",
 		".",
 		"./tests/e2e/plugins/custom-internationalized-plugin",
-		"./tests/e2e/plugins/merge-translations"
+		"./tests/e2e/plugins/merge-translations",
+		"./tests/e2e/plugins/no-merge-translations"
 	]
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -42,7 +42,7 @@ function preferred_languages_boot() {
 	add_action( 'update_user_meta', 'preferred_languages_update_user_meta', 10, 4 );
 	add_filter( 'get_user_metadata', 'preferred_languages_filter_user_locale', 10, 3 );
 	add_filter( 'locale', 'preferred_languages_filter_locale', 5 ); // Before WP_Locale_Switcher.
-	add_filter( 'override_load_textdomain', 'preferred_languages_override_load_textdomain', 10, 3 );
+	add_filter( 'override_load_textdomain', 'preferred_languages_override_load_textdomain', 10, 4 );
 	add_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile', 10 );
 	add_filter( 'pre_load_script_translations', 'preferred_languages_pre_load_script_translations', 10, 4 );
 	add_filter( 'load_script_translation_file', 'preferred_languages_load_script_translation_file' );
@@ -538,13 +538,16 @@ function preferred_languages_filter_user_locale( $value, $object_id, $meta_key )
  *
  * @since 1.7.1
  *
- * @param bool   $override Whether to override the .mo file loading. Default false.
- * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
- * @param string $mofile   Path to the MO file.
+ * @param bool        $override         Whether to override the .mo file loading. Default false.
+ * @param string      $domain           Text domain. Unique identifier for retrieving translated strings.
+ * @param string      $mofile           Path to the MO file.
+ * @param string|null $current_locale   Optional. Locale. Defaults to current locale.
  * @return bool Whether to override the .mo file loading.
  */
-function preferred_languages_override_load_textdomain( $override, $domain, $mofile ) {
-	$current_locale = determine_locale();
+function preferred_languages_override_load_textdomain( $override, $domain, $mofile, $current_locale = null ) {
+	if ( ! isset( $current_locale ) ) {
+		$current_locale = determine_locale();
+	}
 
 	$merge_translations = class_exists( 'WP_Translations' );
 
@@ -595,7 +598,7 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 		}
 	}
 
-	add_filter( 'override_load_textdomain', 'preferred_languages_override_load_textdomain', 10, 3 );
+	add_filter( 'override_load_textdomain', 'preferred_languages_override_load_textdomain', 10, 4 );
 	add_filter( 'load_textdomain_mofile', 'preferred_languages_load_textdomain_mofile' );
 
 	if ( null !== $first_mofile ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -584,8 +584,8 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 	// In that case, only check for de_CH, de_DE, es_ES.
 	if ( preferred_languages_is_locale_switched() ) {
 		$preferred_locales = array_slice(
-				$preferred_locales,
-				array_search( $current_locale, $preferred_locales, true )
+			$preferred_locales,
+			array_search( $current_locale, $preferred_locales, true )
 		);
 	}
 
@@ -703,11 +703,10 @@ function preferred_languages_pre_load_script_translations( $translations, $file,
 	// In that case, only check for de_CH, de_DE, es_ES.
 	if ( preferred_languages_is_locale_switched() ) {
 		$preferred_locales = array_slice(
-				$preferred_locales,
-				array_search( $current_locale, $preferred_locales, true )
+			$preferred_locales,
+			array_search( $current_locale, $preferred_locales, true )
 		);
 	}
-
 
 	remove_filter( 'pre_load_script_translations', 'preferred_languages_pre_load_script_translations' );
 	remove_filter( 'load_script_translation_file', 'preferred_languages_load_script_translation_file' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -577,6 +577,18 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 		return $override;
 	}
 
+	// If locale has been switched to a specific locale, ignore the ones before it.
+	// Example:
+	// Preferred Languages: fr_FR, de_CH, de_DE, es_ES.
+	// Switched to locale: de_CH
+	// In that case, only check for de_CH, de_DE, es_ES.
+	if ( preferred_languages_is_locale_switched() ) {
+		$preferred_locales = array_slice(
+				$preferred_locales,
+				array_search( $current_locale, $preferred_locales, true )
+		);
+	}
+
 	$first_mofile = null;
 
 	remove_filter( 'override_load_textdomain', 'preferred_languages_override_load_textdomain' );
@@ -664,8 +676,10 @@ function preferred_languages_load_textdomain_mofile( $mofile ) {
 function preferred_languages_pre_load_script_translations( $translations, $file, $handle, $domain ) {
 	$current_locale = determine_locale();
 
+	$merge_translations = class_exists( 'WP_Translations' );
+
 	/** This filter is documented in inc/functions.php */
-	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
+	$merge_translations = apply_filters( 'preferred_languages_merge_translations', $merge_translations, $domain, $current_locale );
 
 	if ( ! $merge_translations ) {
 		return $translations;
@@ -681,6 +695,19 @@ function preferred_languages_pre_load_script_translations( $translations, $file,
 	if ( ! in_array( $current_locale, $preferred_locales, true ) ) {
 		return $translations;
 	}
+
+	// If locale has been switched to a specific locale, ignore the ones before it.
+	// Example:
+	// Preferred Languages: fr_FR, de_CH, de_DE, es_ES.
+	// Switched to locale: de_CH
+	// In that case, only check for de_CH, de_DE, es_ES.
+	if ( preferred_languages_is_locale_switched() ) {
+		$preferred_locales = array_slice(
+				$preferred_locales,
+				array_search( $current_locale, $preferred_locales, true )
+		);
+	}
+
 
 	remove_filter( 'pre_load_script_translations', 'preferred_languages_pre_load_script_translations' );
 	remove_filter( 'load_script_translation_file', 'preferred_languages_load_script_translation_file' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -546,6 +546,8 @@ function preferred_languages_filter_user_locale( $value, $object_id, $meta_key )
 function preferred_languages_override_load_textdomain( $override, $domain, $mofile ) {
 	$current_locale = determine_locale();
 
+	$merge_translations = class_exists( 'WP_Translations' );
+
 	/**
 	 * Filters whether translations should be merged with existing ones.
 	 *
@@ -555,7 +557,7 @@ function preferred_languages_override_load_textdomain( $override, $domain, $mofi
 	 * @param string $domain         The text domain
 	 * @param string $current_locale The current locale.
 	 */
-	$merge_translations = apply_filters( 'preferred_languages_merge_translations', false, $domain, $current_locale );
+	$merge_translations = apply_filters( 'preferred_languages_merge_translations', $merge_translations, $domain, $current_locale );
 
 	if ( ! $merge_translations ) {
 		return $override;

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Preferred Languages ===
 Contributors: swissspidy
 Tags: internationalization, i18n, localization, l10n, language, locale, translation
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 2.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/e2e/plugins/no-merge-translations/no-merge-translations.php
+++ b/tests/e2e/plugins/no-merge-translations/no-merge-translations.php
@@ -1,0 +1,11 @@
+<?php
+/*
+Plugin Name: No Merge Translations
+Plugin URI: https://wordpress.org/
+Description: For testing purposes only.
+Version: 1.0.0
+Text Domain: merge-translations
+Domain Path: languages/
+*/
+
+add_filter( 'preferred_languages_merge_translations', '__return_false' );

--- a/tests/e2e/plugins/no-merge-translations/no-merge-translations.php
+++ b/tests/e2e/plugins/no-merge-translations/no-merge-translations.php
@@ -4,7 +4,7 @@ Plugin Name: No Merge Translations
 Plugin URI: https://wordpress.org/
 Description: For testing purposes only.
 Version: 1.0.0
-Text Domain: merge-translations
+Text Domain: no-merge-translations
 Domain Path: languages/
 */
 

--- a/tests/e2e/specs/translationLoading.ts
+++ b/tests/e2e/specs/translationLoading.ts
@@ -184,7 +184,7 @@ describe( 'Translation Loading', () => {
 			Switched to es_ES: True
 			Current Locale: es_ES
 			Output:
-			Das ist ein Dummy Plugin
+			Este es un plugin dummy
 			Este es otro plugin dummy"
 		`
 			);
@@ -260,7 +260,7 @@ describe( 'Translation Loading', () => {
 				Switched to es_ES: True
 				Current Locale: es_ES
 				Output:
-				Das ist ein Dummy Plugin
+				Este es un plugin dummy
 				Este es otro plugin dummy"
 					`
 				);

--- a/tests/e2e/specs/translationLoading.ts
+++ b/tests/e2e/specs/translationLoading.ts
@@ -35,12 +35,14 @@ describe( 'Translation Loading', () => {
 		] );
 
 		await activatePlugin( 'custom-internationalized-plugin' );
+		await activatePlugin( 'no-merge-translations' );
 		await deactivatePlugin( 'merge-translations' );
 		await deactivatePlugin( 'performant-translations' );
 	} );
 
 	afterAll( async () => {
 		await deactivatePlugin( 'custom-internationalized-plugin' );
+		await deactivatePlugin( 'no-merge-translations' );
 
 		// Extra space just so page.type() types something to clear the input field.
 		await setOption( 'preferred_languages', ' ' );
@@ -122,11 +124,13 @@ describe( 'Translation Loading', () => {
 
 	describe( 'Merging Translations', () => {
 		beforeAll( async () => {
+			await deactivatePlugin( 'no-merge-translations' );
 			await activatePlugin( 'merge-translations' );
 		} );
 
 		afterAll( async () => {
 			await deactivatePlugin( 'merge-translations' );
+			await activatePlugin( 'no-merge-translations' );
 		} );
 
 		it( 'should correctly translate strings', async () => {

--- a/tests/phpunit/tests/plugin.php
+++ b/tests/phpunit/tests/plugin.php
@@ -1064,6 +1064,8 @@ class Plugin_Test extends WP_UnitTestCase {
 	 * @covers ::preferred_languages_pre_load_script_translations
 	 */
 	public function test_pre_load_script_translations_no_merge() {
+		add_filter( 'preferred_languages_merge_translations', '__return_false' );
+
 		update_option( 'preferred_languages', 'de_DE,fr_FR' );
 
 		$actual1 = preferred_languages_pre_load_script_translations( false, 'file', 'handle', 'default' );

--- a/tests/phpunit/tests/plugin.php
+++ b/tests/phpunit/tests/plugin.php
@@ -1485,6 +1485,27 @@ class Plugin_Test extends WP_UnitTestCase {
 	 * @covers ::preferred_languages_load_just_in_time
 	 */
 	public function test_filter_gettext_plugin_custom_path_locale_switching() {
+		add_filter( 'preferred_languages_merge_translations', '__return_false' );
+		update_option( 'preferred_languages', 'fr_FR,de_DE,es_ES' );
+
+		require_once WP_PLUGIN_DIR . '/custom-internationalized-plugin/custom-internationalized-plugin.php';
+
+		switch_to_locale( 'de_DE' );
+		$actual_de = custom_i18n_plugin_test();
+		switch_to_locale( 'es_ES' );
+		$actual_es = custom_i18n_plugin_test();
+		restore_current_locale();
+
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual_de );
+		$this->assertSame( 'Este es un plugin dummy', $actual_es );
+	}
+
+	/**
+	 * @covers ::preferred_languages_filter_gettext
+	 * @covers ::preferred_languages_load_just_in_time
+	 */
+	public function test_filter_gettext_plugin_custom_path_locale_switching_merge_translations() {
+		add_filter( 'preferred_languages_merge_translations', '__return_true' );
 		update_option( 'preferred_languages', 'fr_FR,de_DE,es_ES' );
 
 		require_once WP_PLUGIN_DIR . '/custom-internationalized-plugin/custom-internationalized-plugin.php';

--- a/tests/phpunit/tests/plugin.php
+++ b/tests/phpunit/tests/plugin.php
@@ -42,15 +42,23 @@ class Plugin_Test extends WP_UnitTestCase {
 		// Prevents WP_Language_Pack_Upgrader from downloading and overriding language packs.
 		add_filter( 'file_mod_allowed', array( $this, 'filter_file_mod_allowed' ), 10, 2 );
 		add_filter( 'upgrader_pre_install', array( $this, 'filter_upgrader_pre_install' ) );
+
+		unload_textdomain( 'custom-internationalized-plugin' );
+		unload_textdomain( 'internationalized-plugin' );
+		unload_textdomain( 'default' );
 	}
 
 	public function tear_down() {
 		delete_option( 'preferred_languages' );
 		delete_site_option( 'preferred_languages' );
 
-		remove_filter( 'preferred_languages_merge_translations', '__return_true' );
+		remove_all_filters( 'preferred_languages_merge_translations' );
 
 		$this->rmdir( WP_LANG_DIR );
+
+		unload_textdomain( 'custom-internationalized-plugin' );
+		unload_textdomain( 'internationalized-plugin' );
+		unload_textdomain( 'default' );
 
 		parent::tear_down();
 	}


### PR DESCRIPTION
- Enable merging by default for WP 6.5+
- Fixes some failing uncovered by that test
- Only call `determine_locale()` when not already provided

See #864