### PR TITLE
Remove unused import `useSelect`

### DIFF
--- a/src/components/PreferredLanguages.tsx
+++ b/src/components/PreferredLanguages.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import {


### PR DESCRIPTION
The imported `useSelect` is not used in the file, so we can remove it.