### PR TITLE
Deprecated: Use `variant="secondary"` instead of `isSecondary`

### DIFF
--- a/src/components/ActiveLocales.tsx
+++ b/src/components/ActiveLocales.tsx
@@ -246,7 +246,7 @@ function ActiveControls( {
 			<ul>
 				<li>
 					<Button
-						isSecondary
+						variant="secondary"
 						showTooltip
 						aria-keyshortcuts="ArrowUp"
 						aria-label={ sprintf(
@@ -267,7 +267,7 @@ function ActiveControls( {
 				</li>
 				<li>
 					<Button
-						isSecondary
+						variant="secondary"
 						showTooltip
 						aria-keyshortcuts="ArrowDown"
 						aria-label={ sprintf(
@@ -288,7 +288,7 @@ function ActiveControls( {
 				</li>
 				<li>
 					<Button
-						isSecondary
+						variant="secondary"
 						showTooltip
 						aria-keyshortcuts="Delete"
 						aria-label={ sprintf(

--- a/src/components/InactiveLocales.tsx
+++ b/src/components/InactiveLocales.tsx
@@ -179,7 +179,7 @@ function InactiveControls( { disabled, onClick }: InactiveControlsProps ) {
 	return (
 		<div className="inactive-locales-controls">
 			<Button
-				isSecondary
+				variant="secondary"
 				showTooltip
 				aria-keyshortcuts="Alt+A"
 				aria-label={ sprintf(


### PR DESCRIPTION
The prop `isSecondary` is deprecated. We should use `variant` prop with `secondary` value instead. See: https://developer.wordpress.org/block-editor/reference-guides/components/button/#props