### PR TITLE
Update `WPLANG` option in addition to filtering

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -389,6 +389,16 @@ function preferred_languages_add_option( $option, $value ) {
 	$locales = array_filter( explode( ',', $value ) );
 	preferred_languages_download_language_packs( $locales );
 
+	/*
+	 * In addition to filtering the WPLANG option, also update it in the database,
+	 * in case any plugin accesses it before this plugin is loaded.
+	 */
+	if ( ! empty( $locales ) ) {
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		update_option( 'WPLANG', reset( $locales ) );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+	}
+
 	// Reload translations after save.
 	load_default_textdomain( determine_locale() );
 }
@@ -413,12 +423,22 @@ function preferred_languages_update_option( $old_value, $value ) {
 	$locales = array_filter( explode( ',', $value ) );
 	preferred_languages_download_language_packs( $locales );
 
+	/*
+	 * In addition to filtering the WPLANG option, also update it in the database,
+	 * in case any plugin accesses it before this plugin is loaded.
+	 */
+	if ( ! empty( $locales ) ) {
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		update_option( 'WPLANG', reset( $locales ) );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+	}
+
 	// Reload translations after save.
 	load_default_textdomain( determine_locale() );
 }
 
 /**
- * Downloads language packs upon updating the network option.
+ * Downloads language packs upon adding or updating the network option.
  *
  * @since 1.7.0
  *
@@ -432,6 +452,16 @@ function preferred_languages_update_site_option( $option, $value ) {
 
 	$locales = array_filter( explode( ',', $value ) );
 	preferred_languages_download_language_packs( $locales );
+
+	/*
+	 * In addition to filtering the WPLANG site option, also update it in the database,
+	 * in case any plugin accesses it before this plugin is loaded.
+	 */
+	if ( ! empty( $locales ) ) {
+		remove_filter( 'pre_site_option_WPLANG', 'preferred_languages_filter_option' );
+		update_site_option( 'WPLANG', reset( $locales ) );
+		add_filter( 'pre_site_option_WPLANG', 'preferred_languages_filter_option' );
+	}
 
 	// Reload translations after save.
 	load_default_textdomain( determine_locale() );

--- a/tests/phpunit/tests/plugin.php
+++ b/tests/phpunit/tests/plugin.php
@@ -707,6 +707,19 @@ class Plugin_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::preferred_languages_add_option
+	 */
+	public function test_add_option_updates_wplang_option() {
+		update_option( 'preferred_languages', 'de_DE,fr_FR' );
+
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		$raw_locale = get_option( 'WPLANG' );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+
+		$this->assertSame( 'de_DE', $raw_locale );
+	}
+
+	/**
+	 * @covers ::preferred_languages_add_option
 	 * @covers ::preferred_languages_update_option
 	 */
 	public function test_update_option_downloads_language_packs_again() {
@@ -740,6 +753,21 @@ class Plugin_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::preferred_languages_update_option
+	 */
+	public function test_update_option_updates_wplang_option() {
+		update_option( 'preferred_languages', 'de_DE,fr_FR' );
+		update_option( 'preferred_languages', '' );
+		update_option( 'preferred_languages', 'de_DE,fr_FR' );
+
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		$raw_locale = get_option( 'WPLANG' );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+
+		$this->assertSame( 'de_DE', $raw_locale );
+	}
+
+	/**
 	 * @covers ::preferred_languages_add_option
 	 */
 	public function test_add_option_empty_list() {
@@ -770,6 +798,19 @@ class Plugin_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::preferred_languages_update_site_option
+	 */
+	public function test_add_site_option_updates_wplang_site_option() {
+		update_site_option( 'preferred_languages', 'de_DE,fr_FR' );
+
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		$raw_locale = get_site_option( 'WPLANG' );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+
+		$this->assertSame( 'de_DE', $raw_locale );
+	}
+
+	/**
+	 * @covers ::preferred_languages_update_site_option
 	 * @group ms-required
 	 */
 	public function test_update_site_option_downloads_language_packs_again() {
@@ -787,6 +828,21 @@ class Plugin_Test extends WP_UnitTestCase {
 		update_site_option( 'preferred_languages', 'de_DE,fr_FR' );
 		update_site_option( 'preferred_languages', 'de_DE,fr_FR' );
 		$this->assertSame( 2, $this->download_language_packs_action->get_call_count() );
+	}
+
+	/**
+	 * @covers ::preferred_languages_update_site_option
+	 */
+	public function test_update_site_option_updates_wplang_site_option() {
+		update_site_option( 'preferred_languages', 'de_DE,fr_FR' );
+		update_site_option( 'preferred_languages', '' );
+		update_site_option( 'preferred_languages', 'de_DE,fr_FR' );
+
+		remove_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+		$raw_locale = get_site_option( 'WPLANG' );
+		add_filter( 'pre_option_WPLANG', 'preferred_languages_filter_option' );
+
+		$this->assertSame( 'de_DE', $raw_locale );
 	}
 
 	public function data_test_sanitize_list() {


### PR DESCRIPTION
In addition to filtering the WPLANG (site) option, also update it in the database, in case any plugin accesses it before this plugin is loaded.

This can happen for example when another plugin calls `get_locale()` directly in the main plugin file, without waiting for `init` or `plugins_loaded`, and if that plugin is loaded before Preferred Languages (the list of active plugins is sorted alphabetically).